### PR TITLE
Refactor how the bot parses tupperbox messages

### DIFF
--- a/handlers/messageDelete.js
+++ b/handlers/messageDelete.js
@@ -1,17 +1,59 @@
 const { updateRoleplayLog } = require("../dataAccessors.js");
-const { hasRoleplay } = require("../logic.js");
+const { hasRoleplay, stripTupperReplies } = require("../logic.js");
 
-const messageDelete = async (message) => {
-    // if a roleplay message is deleted, we should mark it as such in the DB.
-    // this includes when tupper deletes a message.  in the message handler,
-    // when tupper creates the replacement message, we un-delete the original
-    // and update the message ID to point to the tupper one.
+const messageDelete = async (message, pendingBotMessages) => {
+    // we can't see who has deleted a message, so we need to treat all deletions
+    // the same.  create a timeout which will perform the actual deletion.  then,
+    // in the pendingBotMessages array, we store an object with the message ID,
+    // timeout ID, and message text.  If the message was deleted because Tupper is
+    // about to post on behalf of an avatar, we will compare it to the text in this
+    // array and use it to update the message instead of deleting it.
     const isRoleplay = await hasRoleplay(message);
     if (isRoleplay) {
-        updateRoleplayLog(
-            { deletedAt: new Date().getTime() },
-            { where: { messageId: message.id } }
-        );
+        const text = stripTupperReplies(message.content.trim());
+        setTimeout(() => {
+            // see if this message matches one in pendingBotMessages
+            const botMessageIdx = pendingBotMessages.findIndex(
+                (m) => text.indexOf(m.text) > -1
+            );
+            if (botMessageIdx > -1) {
+                // if it matches, update the log with the tupper message ID & length
+                updateRoleplayLog(
+                    {
+                        messageId: pendingBotMessages[botMessageIdx].id, // change the ID to reflect the tupper message
+                        length: pendingBotMessages[botMessageIdx].text.length, // instead of the user message
+                    },
+                    {
+                        where: {
+                            messageId: message.id,
+                        },
+                    }
+                );
+            } else {
+                // if there's no match, this is a real deletion
+                updateRoleplayLog(
+                    { deletedAt: new Date().getTime() },
+                    { where: { messageId: message.id } }
+                );
+            }
+            // clean up the pending messages array
+            for (var i = pendingBotMessages.length - 1; i >= 0; i--) {
+                // is the current message
+                const isThisMessage =
+                    pendingBotMessages[i].id ===
+                    pendingBotMessages[botMessageIdx || 0];
+
+                // is an expired message - over 5 seconds old
+                const isOldMessage =
+                    pendingBotMessages[i].timestamp >= Date.now() / 1000 - 5;
+
+                // if it's this message or an old message, remove from the pendingBotMessages array
+                if (isThisMessage || isOldMessage) {
+                    pendingBotMessages.splice(i, 1);
+                }
+            }
+            console.log(pendingBotMessages);
+        }, 5000);
     }
 };
 

--- a/handlers/messageUpdate.js
+++ b/handlers/messageUpdate.js
@@ -1,20 +1,14 @@
-const crypto = require("crypto");
-
 const { updateRoleplayLog } = require("../dataAccessors.js");
-const { hasRoleplay, trimText } = require("../logic.js");
+const { hasRoleplay } = require("../logic.js");
 
 const messageUpdate = async (oldMessage, newMessage) => {
     // when a roleplay message is updated, we should update the DB
-    // with the new length and the new hash (unique identifier)
+    // with the new length
     const isRoleplay = await hasRoleplay(oldMessage);
     if (isRoleplay) {
-        const trimmedText = trimText(newMessage.content);
-        const hash = crypto
-            .createHash("sha1")
-            .update(trimmedText)
-            .digest("base64");
+        const trimmedText = newMessage.content.trim();
         updateRoleplayLog(
-            { hash, length: trimmedText.length },
+            { length: trimmedText.length },
             { where: { messageId: oldMessage.id } }
         );
     }

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const { message } = require("./handlers/message.js");
 const { messageDelete } = require("./handlers/messageDelete.js");
 const { messageUpdate } = require("./handlers/messageUpdate.js");
 
+const pendingBotMessages = [];
+
 // Initiate our Discord client and let the API know the permissions we need.
 const client = new Client({
     intents: [
@@ -37,10 +39,12 @@ client.on("messageReactionAdd", async (reaction) =>
 );
 
 // Message sent
-client.on("message", async (msg) => message(msg, client));
+client.on("message", async (msg) => message(msg, client, pendingBotMessages));
 
 // Message deleted
-client.on("messageDelete", messageDelete);
+client.on("messageDelete", async (msg) => {
+    messageDelete(msg, pendingBotMessages);
+});
 
 // Message edited
 client.on("messageUpdate", messageUpdate);

--- a/logic.js
+++ b/logic.js
@@ -1,5 +1,3 @@
-const crypto = require("crypto");
-
 const { getLeaderboard, getRoleplayFilters } = require("./dataAccessors.js");
 
 // chunks a messages into several messages under 2000 characters
@@ -84,23 +82,6 @@ const hasRoleplay = async (message) => {
     return Boolean(hasFilter);
 };
 
-const sleep = (ms) => {
-    // generic wait function
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
-};
-
-const trimText = (text) => {
-    // trims whitespace from text and removes the tupper shortcut if it finds one
-    let trimmedText = text;
-    const colonIdx = trimmedText.indexOf(":");
-    if (colonIdx > -1 && colonIdx <= 16) {
-        trimmedText = text.substring(colonIdx + 1).trim();
-    }
-    return trimmedText;
-};
-
 const generateLeaderboard = async (message, label, from, to, client) => {
     // get the list of leaders from the database
     const leaders = await getLeaderboard(from, to);
@@ -130,16 +111,28 @@ ${leadersOutput}
 \`\`\``;
 };
 
-// generates a unique identifier for a given string
-const generateHash = (text) =>
-    crypto.createHash("sha1").update(text).digest("base64");
+const stripTupperReplies = (text) => {
+    // if the first line is a quote
+    if (text.substring(0, 2) === "> ") {
+        // split the text into an array of lines
+        const textArray = text.split("\n");
+        // remove the quote
+        textArray.splice(0, 1);
+        // check if the second line is an at-tag - tupper does this
+        if (textArray[0].substring(0, 1) === "@") {
+            // remove the second line
+            textArray.splice(0, 1);
+        }
+        // re-join the array and return
+        return textArray.join("\n");
+    }
+    return text;
+};
 
 module.exports = {
     chunkMessage,
-    generateHash,
     generateLeaderboard,
     getWebhook,
     hasRoleplay,
-    sleep,
-    trimText,
+    stripTupperReplies,
 };


### PR DESCRIPTION
Previously, when a user sent a message, a hash of that message's text was stored in the DB, and then if tupper came along and replaced that message, the bot would compare the hash of the new message with the hashes of the messages in the DB to find the message it had replaced, and then update that message.

This had two big problems:
• Writes to the DB were slow and resulted in a situation where sometimes we would try undeleting a message before the original deletion had been written.
• The parser that created the hash assumed that tupper messages from the user always came in the format `ABC:text`, which is not true - there can be anything before and after the `text` section of the shortcut syntax.

This PR replaces that system with a totally new one.  Now, instead of storing the hash, we store the entire value of the message. This way, we can do a substring comparison for tupper's message, no matter what the shortcut syntax is before and after. We also now store the values to check in memory - since tupper replaces the message very quickly, there's no reason we need to store it for more than a few seconds.